### PR TITLE
APB-10851 update HIP header and port

### DIFF
--- a/app/uk/gov/hmrc/agentservicesaccount/connectors/HipConnector.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/connectors/HipConnector.scala
@@ -34,6 +34,7 @@ import uk.gov.hmrc.http.StringContextOps
 import uk.gov.hmrc.http.client.HttpClientV2
 
 import java.net.URL
+import java.time.temporal.ChronoUnit.SECONDS
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -83,7 +84,7 @@ with Logging {
       "Authorization" -> s"Basic $authToken",
       "correlationid" -> UUID.randomUUID().toString,
       "X-Originating-System" -> originatingSystem,
-      "X-Receipt-Date" -> java.time.Instant.now().toString,
+      "X-Receipt-Date" -> java.time.Instant.now().truncatedTo(SECONDS).toString,
       "X-Transmitting-System" -> transmittingSystem
     )
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -91,7 +91,7 @@ microservice {
 
     hip {
       host = localhost
-      port = 9905
+      port = 9009
       environment = test
       authorization-token = secret
     }


### PR DESCRIPTION
- Update date header with the stub compatible format
- Update port since we don't have a proxy port setup for hip on agents-external-stubs so we need to use the port for AES, 9009